### PR TITLE
Enable embedded dashboards demo

### DIFF
--- a/embed_demo.html
+++ b/embed_demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Superset Embedded Dashboard Demo</title>
+  <script src="https://unpkg.com/@superset-ui/embedded-sdk"></script>
+</head>
+<body>
+  <h1>Embedded Dashboard Example</h1>
+  <div id="superset-container" style="width:800px;height:600px;"></div>
+  <script>
+    // Replace with the UUID for the dashboard you enabled for embedding
+    const dashboardId = "YOUR_DASHBOARD_UUID";
+
+    // This callback should retrieve a guest token from your backend
+    async function fetchGuestToken() {
+      const response = await fetch('/api/guestToken');
+      const data = await response.json();
+      return data.token;
+    }
+
+    supersetEmbeddedSdk.embedDashboard({
+      id: dashboardId,
+      supersetDomain: window.location.origin,
+      mountPoint: document.getElementById('superset-container'),
+      fetchGuestToken,
+      dashboardUiConfig: {
+        hideTitle: true,
+        filters: { expanded: true }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/superset/config.py
+++ b/superset/config.py
@@ -518,7 +518,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "DASHBOARD_VIRTUALIZATION": True,
     # This feature flag is stil in beta and is not recommended for production use.
     "GLOBAL_ASYNC_QUERIES": False,
-    "EMBEDDED_SUPERSET": False,
+    # Enable embedding dashboards via the embedded SDK
+    "EMBEDDED_SUPERSET": True,
     # Enables Alerts and reports new implementation
     "ALERT_REPORTS": False,
     "ALERT_REPORT_TABS": False,


### PR DESCRIPTION
## Summary
- turn on `EMBEDDED_SUPERSET` feature flag
- add an `embed_demo.html` page that shows how to embed a dashboard

## Testing
- `pre-commit run --files superset/config.py embed_demo.html`

------
https://chatgpt.com/codex/tasks/task_e_686e9a21c974832e82ff104854458075