### PR TITLE
Add CORS extras to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,9 @@ FROM python-common AS lean
 COPY requirements/base.txt requirements/
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     /app/docker/pip-install.sh --requires-build-essential -r requirements/base.txt
-# Install the superset package
+# Install the optional CORS dependencies first, then the Superset package
+RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
+    uv pip install apache_superset[cors]
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     uv pip install .
 RUN python -m compileall /app/superset
@@ -244,7 +246,9 @@ COPY requirements/*.txt requirements/
 # Install Python dependencies using docker/pip-install.sh
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     /app/docker/pip-install.sh --requires-build-essential -r requirements/development.txt
-# Install the superset package
+# Install the optional CORS dependencies first, then the Superset package
+RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
+    uv pip install apache_superset[cors]
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     uv pip install .
 


### PR DESCRIPTION
## Summary
- ensure optional CORS dependencies are installed when building Docker images

## Testing
- `pytest -k 'this_does_not_exist'` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas`

------
https://chatgpt.com/codex/tasks/task_e_686eb320cc9c832e89c63cd11d7b1ce7